### PR TITLE
Lock onboarding flow to edu97 server

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@
 # The setting is particularly useful for tweaking memory settings.
 
 # Build Time Optimizations
-org.gradle.jvmargs=-Xmx4g -Xms512M -XX:MaxPermSize=2048m -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC
+org.gradle.jvmargs=-Xmx4g -Xms512M -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC
 org.gradle.configureondemand=true
 org.gradle.parallel=true
 org.gradle.vfs.watch=true

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedLoginFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthCombinedLoginFragment.kt
@@ -27,7 +27,6 @@ import im.vector.app.core.extensions.setOnFocusLostListener
 import im.vector.app.core.extensions.setOnImeDoneListener
 import im.vector.app.core.extensions.toReducedUrl
 import im.vector.app.databinding.FragmentFtueCombinedLoginBinding
-import im.vector.app.features.VectorFeatures
 import im.vector.app.features.login.LoginMode
 import im.vector.app.features.login.SSORedirectRouterActivity
 import im.vector.app.features.login.SocialLoginButtonsView
@@ -48,7 +47,6 @@ class FtueAuthCombinedLoginFragment :
 
     @Inject lateinit var loginFieldsValidation: LoginFieldsValidation
     @Inject lateinit var loginErrorParser: LoginErrorParser
-    @Inject lateinit var vectorFeatures: VectorFeatures
 
     override fun getBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentFtueCombinedLoginBinding {
         return FragmentFtueCombinedLoginBinding.inflate(inflater, container, false)
@@ -58,7 +56,8 @@ class FtueAuthCombinedLoginFragment :
         super.onViewCreated(view, savedInstanceState)
         setupSubmitButton()
         views.loginRoot.realignPercentagesToParent()
-        views.editServerButton.debouncedClicks { viewModel.handle(OnboardingAction.PostViewEvent(OnboardingViewEvents.EditServerSelection)) }
+        views.editServerButton.isVisible = false
+        views.editServerButton.setOnClickListener(null)
         views.loginPasswordInput.setOnImeDoneListener { submit() }
         views.loginInput.setOnFocusLostListener(viewLifecycleOwner) {
             viewModel.handle(OnboardingAction.UserNameEnteredAction.Login(views.loginInput.content()))

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSplashFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthSplashFragment.kt
@@ -16,11 +16,9 @@ import androidx.core.view.isVisible
 import dagger.hilt.android.AndroidEntryPoint
 import im.vector.app.core.resources.BuildMeta
 import im.vector.app.databinding.FragmentFtueAuthSplashBinding
-import im.vector.app.features.VectorFeatures
 import im.vector.app.features.onboarding.OnboardingAction
 import im.vector.app.features.onboarding.OnboardingFlow
 import im.vector.app.features.settings.VectorPreferences
-import im.vector.lib.strings.CommonStrings
 import javax.inject.Inject
 
 /**
@@ -31,7 +29,6 @@ class FtueAuthSplashFragment :
         AbstractFtueAuthFragment<FragmentFtueAuthSplashBinding>() {
 
     @Inject lateinit var vectorPreferences: VectorPreferences
-    @Inject lateinit var vectorFeatures: VectorFeatures
     @Inject lateinit var buildMeta: BuildMeta
 
     override fun getBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentFtueAuthSplashBinding {
@@ -41,18 +38,16 @@ class FtueAuthSplashFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupViews()
+        if (savedInstanceState == null) {
+            alreadyHaveAnAccount()
+        }
     }
 
     private fun setupViews() {
-        val isAlreadyHaveAccountEnabled = vectorFeatures.isOnboardingAlreadyHaveAccountSplashEnabled()
-        views.loginSplashSubmit.apply {
-            setText(if (isAlreadyHaveAccountEnabled) CommonStrings.login_splash_create_account else CommonStrings.login_splash_submit)
-            debouncedClicks { splashSubmit(isAlreadyHaveAccountEnabled) }
-        }
-        views.loginSplashAlreadyHaveAccount.apply {
-            isVisible = vectorFeatures.isOnboardingAlreadyHaveAccountSplashEnabled()
-            debouncedClicks { alreadyHaveAnAccount() }
-        }
+        views.loginSplashSubmit.isVisible = false
+        views.loginSplashSubmit.setOnClickListener(null)
+        views.loginSplashAlreadyHaveAccount.isVisible = false
+        views.loginSplashAlreadyHaveAccount.setOnClickListener(null)
 
         if (buildMeta.isDebug || vectorPreferences.developerMode()) {
             views.loginSplashVersion.isVisible = true
@@ -61,11 +56,6 @@ class FtueAuthSplashFragment :
                     "Branch: ${buildMeta.gitBranchName} ${buildMeta.gitRevision}"
             views.loginSplashVersion.debouncedClicks { navigator.openDebug(requireContext()) }
         }
-    }
-
-    private fun splashSubmit(isAlreadyHaveAccountEnabled: Boolean) {
-        val getStartedFlow = if (isAlreadyHaveAccountEnabled) OnboardingFlow.SignUp else OnboardingFlow.SignInSignUp
-        viewModel.handle(OnboardingAction.SplashAction.OnGetStarted(onboardingFlow = getStartedFlow))
     }
 
     private fun alreadyHaveAnAccount() {

--- a/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
+++ b/vector/src/main/java/im/vector/app/features/onboarding/ftueauth/FtueAuthVariant.kt
@@ -109,11 +109,7 @@ class FtueAuthVariant(
     }
 
     private fun addFirstFragment() {
-        val splashFragment = when (vectorFeatures.isOnboardingSplashCarouselEnabled()) {
-            true -> FtueAuthSplashCarouselFragment::class.java
-            else -> FtueAuthSplashFragment::class.java
-        }
-        activity.addFragment(views.loginFragmentContainer, splashFragment)
+        activity.addFragment(views.loginFragmentContainer, FtueAuthSplashFragment::class.java)
     }
 
     private fun updateWithState(viewState: OnboardingViewState) {
@@ -217,14 +213,7 @@ class FtueAuthVariant(
             OnboardingViewEvents.OnChooseProfilePicture -> onChooseProfilePicture()
             OnboardingViewEvents.OnPersonalizationComplete -> onPersonalizationComplete()
             OnboardingViewEvents.OnBack -> activity.popBackstack()
-            OnboardingViewEvents.EditServerSelection -> {
-                activity.addFragmentToBackstack(
-                        views.loginFragmentContainer,
-                        FtueAuthCombinedServerSelectionFragment::class.java,
-                        option = commonOption,
-                        tag = FRAGMENT_EDIT_HOMESERVER_TAG
-                )
-            }
+            OnboardingViewEvents.EditServerSelection -> Unit
             OnboardingViewEvents.OnHomeserverEdited -> {
                 supportFragmentManager.popBackStack(
                         FRAGMENT_EDIT_HOMESERVER_TAG,


### PR DESCRIPTION
## Summary
- auto-trigger the sign-in flow from the splash screen and remove UI that offered other onboarding choices
- hide the server selection controls on the combined login screen so users authenticate only against edu97.ir
- drop the deprecated MaxPermSize JVM argument so Gradle can run with modern JDKs

## Testing
- ./gradlew assembleFdroidArm64Debug *(fails: plugin org.jlleitschuh.gradle.ktlint:11.3.2 unavailable in the current environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e3e589f340832eb354ca62032b3277