### PR TITLE
Switch to legacy onboarding and adjust Gradle plugin resolution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,11 @@ buildscript {
         classpath libs.gradle.hiltPlugin
         classpath 'com.google.firebase:firebase-appdistribution-gradle:4.0.0'
         classpath 'com.google.gms:google-services:4.3.15'
+        classpath 'org.jlleitschuh.gradle:ktlint-gradle:11.3.2'
+        classpath 'io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.7'
+        classpath 'com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:1.9.24-1.0.20'
+        classpath 'com.autonomousapps:dependency-analysis-gradle-plugin:1.20.0'
+        classpath 'com.osacky.doctor:doctor-plugin:0.8.1'
         classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:4.0.0.2929'
         classpath 'com.google.android.gms:oss-licenses-plugin:0.10.6'
         classpath "com.likethesalad.android:stem-plugin:2.9.0"
@@ -39,19 +44,10 @@ buildscript {
     }
 }
 
-plugins {
-    // ktlint Plugin
-    id "org.jlleitschuh.gradle.ktlint" version "11.3.2"
-    // Detekt
-    id "io.gitlab.arturbosch.detekt" version "1.23.7"
-    // Ksp
-    id "com.google.devtools.ksp" version "1.9.24-1.0.20"
-
-    // Dependency Analysis
-    id 'com.autonomousapps.dependency-analysis' version "1.20.0"
-    // Gradle doctor
-    id "com.osacky.doctor" version "0.8.1"
-}
+// Plugin classpaths are provided above; apply plugins below using the legacy syntax to
+// avoid relying on the Gradle Plugin Portal resolution which is restricted in this build setup.
+apply plugin: 'com.autonomousapps.dependency-analysis'
+apply plugin: 'com.osacky.doctor'
 
 // https://github.com/jeremylong/DependencyCheck
 apply plugin: 'org.owasp.dependencycheck'

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@
 # The setting is particularly useful for tweaking memory settings.
 
 # Build Time Optimizations
-org.gradle.jvmargs=-Xmx4g -Xms512M -XX:MaxPermSize=2048m -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC
+org.gradle.jvmargs=-Xmx4g -Xms512M -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC
 org.gradle.configureondemand=true
 org.gradle.parallel=true
 org.gradle.vfs.watch=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,11 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        maven { url 'https://maven.google.com' }
+        maven { url 'https://repo1.maven.org/maven2' }
+    }
+}
+
 include ':vector-app'
 include ':vector'
 include ':vector-config'

--- a/vector-config/src/main/java/im/vector/app/config/Config.kt
+++ b/vector-config/src/main/java/im/vector/app/config/Config.kt
@@ -52,7 +52,7 @@ object Config {
     /**
      * The onboarding flow.
      */
-    val ONBOARDING_VARIANT = OnboardingVariant.FTUE_AUTH
+    val ONBOARDING_VARIANT = OnboardingVariant.LEGACY
 
     /**
      * If set, MSC3086 asserted identity messages sent on VoIP calls will cause the call to appear in the room corresponding to the asserted identity.


### PR DESCRIPTION
## Summary
- force the legacy onboarding experience so the app launches straight into username/password login for the configured homeserver
- add plugin management repositories and explicit classpath entries so required Gradle plugins resolve without the plugin DSL
- drop the deprecated MaxPermSize JVM argument from the Gradle daemon configuration

## Testing
- ./gradlew :vector-app:assembleFdroidRelease *(fails: remote Maven repositories respond with HTTP 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e3e589f340832eb354ca62032b3277